### PR TITLE
Gsheet fixup and rounding up config option

### DIFF
--- a/example-conf.yaml
+++ b/example-conf.yaml
@@ -6,6 +6,7 @@ holidays:
   - "Auckland Anniversary Day"
   - "Waitangi Day"
   - "Queen's Birthday"
+  - "Labour Day"
 business_hours:
   start: "09:00"
   end: "17:00"

--- a/example-conf.yaml
+++ b/example-conf.yaml
@@ -9,5 +9,6 @@ holidays:
 business_hours:
   start: "09:00"
   end: "17:00"
+round_shifts_up: true
 ical_url: "http://apps.employment.govt.nz/ical/public-holidays-all.ics"
 timezone: "Pacific/Auckland"

--- a/example-conf.yaml
+++ b/example-conf.yaml
@@ -11,4 +11,4 @@ business_hours:
   end: "17:00"
 round_shifts_up: true
 ical_url: "http://apps.employment.govt.nz/ical/public-holidays-all.ics"
-timezone: "Pacific/Auckland"
+ical_timezone: "Pacific/Auckland"

--- a/pkg/calendar/calendar.go
+++ b/pkg/calendar/calendar.go
@@ -35,7 +35,7 @@ type Calendar struct {
 	calEnd         time.Time
 	calDays        []time.Time
 	calendarHours  map[time.Time]int
-	scheduleConfig *config.ScheduleConfig
+	ScheduleConfig *config.ScheduleConfig
 	calTimezone    *time.Location
 }
 
@@ -62,11 +62,11 @@ func NewCalendar(startDate, endDate time.Time, conf *config.ScheduleConfig) *Cal
 		calEnd:         endDate,
 		calDays:        calDays,
 		calendarHours:  make(map[time.Time]int, 0),
-		scheduleConfig: conf,
+		ScheduleConfig: conf,
 		calTimezone:    loc,
 	}
 	cal.tagAfterhoursAndWeekends()
-	err = cal.parseAndFilterPublicHolidayiCal(cal.scheduleConfig.CalendarURL)
+	err = cal.parseAndFilterPublicHolidayiCal(cal.ScheduleConfig.CalendarURL)
 	if err != nil {
 		panic(err)
 	}
@@ -74,7 +74,7 @@ func NewCalendar(startDate, endDate time.Time, conf *config.ScheduleConfig) *Cal
 }
 
 func (c *Calendar) GetBusinessHours() (time.Time, time.Time) {
-	return c.scheduleConfig.GetBusinessHours()
+	return c.ScheduleConfig.GetBusinessHours()
 }
 func (c *Calendar) addHour(hourStart time.Time, hourType int) {
 	c.calendarHours[hourStart] = hourType
@@ -112,7 +112,7 @@ func (c *Calendar) parseAndFilterPublicHolidayiCal(icsLink string) error {
 					// Start iterating over every hour of the event and add those hours as stat days
 					tr := timerange.New(event.GetStart(), event.GetEnd().Add(time.Duration(-1)*time.Hour), time.Hour)
 					for tr.Next() {
-						adjustedTime := AdjustForTimezone(tr.Current(), c.scheduleConfig.ParsedTimezone)
+						adjustedTime := AdjustForTimezone(tr.Current(), c.ScheduleConfig.ParsedTimezone)
 						c.addHour(adjustedTime, StatHolidayHour)
 					}
 				}
@@ -126,7 +126,7 @@ func (c *Calendar) parseAndFilterPublicHolidayiCal(icsLink string) error {
 // specified in the config.
 // returns true if it's whitelisted, false if it should be ignored
 func (c *Calendar) filterEvent(eventName string) bool {
-	for _, h := range c.scheduleConfig.Holidays {
+	for _, h := range c.ScheduleConfig.Holidays {
 		if eventName == h {
 			return true
 		}

--- a/pkg/calendar/calendar.go
+++ b/pkg/calendar/calendar.go
@@ -2,7 +2,6 @@ package calendar
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	timerange "github.com/leosunmo/timerange-go"
@@ -236,9 +235,8 @@ func AdjustForTimezone(t time.Time, loc *time.Location) time.Time {
 // Google sheets timeformat. Nanoseconds ignored.
 // 48h30m25s -> 48:30:25.000
 func SheetDurationFormat(d time.Duration) string {
-	ds := d.String()
-	h := strings.Split(ds, "h")
-	m := strings.Split(h[1], "m")
-	s := strings.Split(m[1], "s")
-	return fmt.Sprintf("%s:%s:%s.000", h[0], m[0], s[0])
+	seconds := int64(d.Seconds()) % 60
+	minutes := int64(d.Minutes()) % 60
+	hours := int64(d.Hours())
+	return fmt.Sprintf("%02d:%02d:%02d.000", hours, minutes, seconds)
 }

--- a/pkg/calendar/calendar.go
+++ b/pkg/calendar/calendar.go
@@ -69,13 +69,6 @@ func NewCalendar(startDate, endDate time.Time, conf *config.ScheduleConfig) *Cal
 		panic(err)
 	}
 	cal.tagAfterhoursAndWeekends()
-	fmt.Printf("\nBefore return of Cal:\n%+v\n", cal.CalendarHours)
-	fmt.Printf("\nStat Day breakdown:\n")
-	for a, b := range cal.CalendarHours {
-		if b == 4 {
-			fmt.Printf("Stat Day: %s\n", a)
-		}
-	}
 	return &cal
 }
 
@@ -184,7 +177,6 @@ func (c *Calendar) tagAfterhoursAndWeekends() {
 // GetHourTag returns the hour type of the timestamp provided
 func (c *Calendar) GetHourTag(h time.Time) int {
 	hourType, exists := c.CalendarHours[h.Format(time.RFC3339)]
-	fmt.Printf("Time: %s\tHour Type: %d\n", h, hourType)
 	if !exists {
 		return BusinessHour
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,7 +15,7 @@ type ScheduleConfig struct {
 	BusinessHours  businessHoursStruct `json:"business_hours"`
 	RoundShiftsUp  bool                `json:"round_shifts_up"`
 	CalendarURL    string              `json:"ical_url"`
-	Timezone       string              `json:"timezone"`
+	Timezone       string              `json:"ical_timezone"`
 	ParsedTimezone *time.Location
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ const timeShortForm = "15:04"
 type ScheduleConfig struct {
 	Holidays       []string            `json:"holidays,omitempty"`
 	BusinessHours  businessHoursStruct `json:"business_hours"`
+	RoundShiftsUp  bool                `json:"round_shifts_up"`
 	CalendarURL    string              `json:"ical_url"`
 	Timezone       string              `json:"timezone"`
 	ParsedTimezone *time.Location
@@ -25,7 +26,11 @@ type businessHoursStruct struct {
 
 // GetScheduleConfig reads the config from file and returns a ScheduleConfig
 func GetScheduleConfig(configFilePath string) *ScheduleConfig {
-	sc := ScheduleConfig{}
+	// Let's set some defaults for clarity
+	sc := ScheduleConfig{
+		RoundShiftsUp: false,
+		Timezone:      time.Now().Location().String(),
+	}
 	sc.mustUnmarshalScheduleConfig(mustReadScheduleConfigFile(configFilePath))
 	ParsedTimezone, err := time.LoadLocation(sc.Timezone)
 	if err != nil {
@@ -64,4 +69,9 @@ func (sc *ScheduleConfig) GetBusinessHours() (startTime time.Time, endTime time.
 		panic("Failed to parse business time start time")
 	}
 	return startTime, endTime
+}
+
+// ShiftRoundingUp returns true if round_shifts_up is set in the config
+func (sc *ScheduleConfig) ShiftRoundingUp() bool {
+	return sc.RoundShiftsUp
 }

--- a/pkg/pd/pd.go
+++ b/pkg/pd/pd.go
@@ -25,31 +25,32 @@ func ReadShifts(client *pagerduty.Client, conf *config.ScheduleConfig, cal *cale
 	}
 	var scheduleName string
 	us := make(UserShifts)
-	if ds, err := client.GetSchedule(schedule, getschopts); err != nil {
+	ds, err := client.GetSchedule(schedule, getschopts)
+	if err != nil {
 		return "", nil, err
-	} else {
-		scheduleName = ds.Name
-		for _, se := range ds.FinalSchedule.RenderedScheduleEntries {
-			startTime, terr := time.Parse(pdTimeFormat, se.Start)
-			if terr != nil {
-				return "", nil, terr
-			}
-			endTime, terr := time.Parse(pdTimeFormat, se.End)
-			if terr != nil {
-				return "", nil, terr
-			}
-			s := Shift{
-				StartDate:    startTime,
-				EndDate:      endTime,
-				Duration:     endTime.Sub(startTime),
-				ScheduleName: ds.Name,
-				ShiftHours:   make(map[time.Time]int),
-				Calendar:     cal,
-			}
-			s.ProcessHours()
-
-			us[se.User.Summary] = append(us[se.User.Summary], s)
-		}
 	}
+	scheduleName = ds.Name
+	for _, se := range ds.FinalSchedule.RenderedScheduleEntries {
+		startTime, terr := time.Parse(pdTimeFormat, se.Start)
+		if terr != nil {
+			return "", nil, terr
+		}
+		endTime, terr := time.Parse(pdTimeFormat, se.End)
+		if terr != nil {
+			return "", nil, terr
+		}
+		s := Shift{
+			StartDate:    startTime,
+			EndDate:      endTime,
+			Duration:     endTime.Sub(startTime),
+			ScheduleName: ds.Name,
+			ShiftHours:   make(map[time.Time]int),
+			Calendar:     cal,
+		}
+		s.ProcessHours()
+
+		us[se.User.Summary] = append(us[se.User.Summary], s)
+	}
+
 	return scheduleName, us, nil
 }

--- a/pkg/pd/shift.go
+++ b/pkg/pd/shift.go
@@ -1,6 +1,7 @@
 package pd
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/leosunmo/pagerduty-shifts/pkg/calendar"
@@ -37,9 +38,13 @@ type Shift struct {
 // rounds the end date to the nearest hour
 func (s *Shift) ProcessHours() {
 	if s.Duration < time.Minute*30 {
+		if s.Calendar.ScheduleConfig.RoundShiftsUp {
+			s.ShiftHours[s.StartDate] = s.Calendar.GetHourTag(s.StartDate)
+		}
 		return
 	}
 	if s.Duration < time.Hour {
+		fmt.Println("Less than 1 hour")
 		s.ShiftHours[s.StartDate] = s.Calendar.GetHourTag(s.StartDate)
 		return
 	}

--- a/pkg/pd/shift.go
+++ b/pkg/pd/shift.go
@@ -1,7 +1,6 @@
 package pd
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/leosunmo/pagerduty-shifts/pkg/calendar"
@@ -44,7 +43,6 @@ func (s *Shift) ProcessHours() {
 		return
 	}
 	if s.Duration < time.Hour {
-		fmt.Println("Less than 1 hour")
 		s.ShiftHours[s.StartDate] = s.Calendar.GetHourTag(s.StartDate)
 		return
 	}


### PR DESCRIPTION
This is a general tidy up PR as well as adding the rounding up functionality.

Enabling `round_shifts_up` in the config will cause the shift logic to round up to a full hour shift if your shift is less than 30 minutes long. This is to encourage shorter on-call cover and it should be fairly easy to spot any kind of abuse of the round-up system.